### PR TITLE
Update 00_SCANDINAVIA.txt

### DIFF
--- a/history/titles/00_SCANDINAVIA.txt
+++ b/history/titles/00_SCANDINAVIA.txt
@@ -39,14 +39,14 @@ k_sweden = {
 	# v1.10: Changed
 	
 	970.1.1 = {
-		holder = 100504 # Erik Segersäll
+		holder = 100504 # Erik SegersÃ¤ll
 		succession_laws = { scandinavian_elective_succession_law }
 	}
 	995.1.2 = {
-		holder = 100506 # Olof Skötkonung
+		holder = 100506 # Olof SkÃ¶tkonung
 	}
 	1022.1.7 = {
-		holder = 100508 # Anund Jakob "Kolbränna"
+		holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 	}
 	1050.1.16 = {
 		holder = 100509 # Emund den Gamle, aka "Emund Slemme"
@@ -62,7 +62,7 @@ k_sweden = {
 		holder = 100523 # Halsten
 	}
 	1070.12.1 = {
-		holder = 100526 # Håkan Röde
+		holder = 100526 # HÃ¥kan RÃ¶de
 	}
 	1080.12.1 = {
 		holder = 100524 # Inge the Older
@@ -74,7 +74,7 @@ k_sweden = {
 		holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 	}
 	1125.6.6 = {
-		holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+		holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 	}
 	1126.6.6 = {
 		holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -86,7 +86,7 @@ k_sweden = {
 		holder = 200490 # Erik "the Holy"
 	}
 	1160.6.6 = {
-		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 	}
 	1161.6.6 = {
 		holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -107,15 +107,15 @@ k_sweden = {
 		holder = 200609 # Johan, son of Sverker (200604)
 	}
 	1222.3.10 = {
-		holder = 200507 # Erik 'den Läspe och Halte'
+		holder = 200507 # Erik 'den LÃ¤spe och Halte'
 	}
 	
 	1229.11.29 = {
-		holder = 200508 # Knut Holmgersson 'den Långe'
+		holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 	}
 	
 	1234.6.6 = {
-		holder = 200507 # Erik 'den Läspe och Halte', reinstated
+		holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 	}
 	
 	1250.2.2 = {
@@ -123,7 +123,7 @@ k_sweden = {
 	}
 	
 	1275.7.22 = {
-		holder = 450502 # Magnus 'Ladulås'
+		holder = 450502 # Magnus 'LadulÃ¥s'
 	}
 	
 	1290.12.18 = {
@@ -174,7 +174,7 @@ d_svealand = {
 	holder = 100501
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 940.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -184,13 +184,13 @@ d_svealand = {
 }
 970.1.1 = {
 	liege = k_sweden
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
@@ -207,7 +207,7 @@ d_svealand = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -219,7 +219,7 @@ d_svealand = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -231,7 +231,7 @@ d_svealand = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -252,19 +252,19 @@ d_svealand = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -305,7 +305,7 @@ c_upland = {
 	holder = 163108
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 940.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -314,13 +314,13 @@ c_upland = {
 	holder = 100502
 }
 970.1.1 = {
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
@@ -335,7 +335,7 @@ c_upland = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -347,7 +347,7 @@ c_upland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -359,7 +359,7 @@ c_upland = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -380,19 +380,19 @@ c_upland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -426,7 +426,7 @@ c_sodermannaland = {
 	holder = 163108
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 935.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -435,13 +435,13 @@ c_sodermannaland = {
 	holder = 100502
 }
 970.1.1 = {
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
@@ -457,7 +457,7 @@ c_sodermannaland = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -469,7 +469,7 @@ c_sodermannaland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -529,7 +529,7 @@ c_vastmanland = {
 	holder = 6837
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 940.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -538,13 +538,13 @@ c_vastmanland = {
 	holder = 100502
 }
 970.1.1 = {
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1060.8.2 = {
 	holder = 100546 # Erik the Heathen
@@ -557,7 +557,7 @@ c_vastmanland = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -569,7 +569,7 @@ c_vastmanland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -651,7 +651,7 @@ c_dalarna = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -729,7 +729,7 @@ c_dalabergslagen = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -767,7 +767,7 @@ c_dalabergslagen = {
 d_vastergotland = {
 
 500.1.1 = {
-	de_jure_liege = k_sweden
+	de_jure_liege = k_geats
 }
 	760.1.1 = {
 		holder = 194010
@@ -805,7 +805,7 @@ d_vastergotland = {
 		holder = 100523 # Halsten
 	}
 	1070.12.1 = {
-		holder = 100526 # Håkan Röde
+		holder = 100526 # HÃ¥kan RÃ¶de
 	}
 	1080.12.1 = {
 		holder = 100524 # Inge the Older
@@ -817,7 +817,7 @@ d_vastergotland = {
 		holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 	}
 	1125.6.6 = {
-		holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+		holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 	}
 	1126.6.6 = {
 		holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -844,15 +844,15 @@ d_vastergotland = {
 		holder = 200609 # Johan, son of Sverker (200604)
 	}
 	1222.3.10 = {
-		holder = 200507 # Erik 'den Läspe och Halte'
+		holder = 200507 # Erik 'den LÃ¤spe och Halte'
 	}
 	
 	1229.11.29 = {
-		holder = 200508 # Knut Holmgersson 'den Långe'
+		holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 	}
 	
 	1234.6.6 = {
-		holder = 200507 # Erik 'den Läspe och Halte', reinstated
+		holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 	}
 	
 	1250.2.2 = {
@@ -860,7 +860,7 @@ d_vastergotland = {
 	}
 	
 	1284.1.1 = {
-		holder = 450502 # Magnus 'Ladulås'
+		holder = 450502 # Magnus 'LadulÃ¥s'
 	}
 	
 	1290.12.18 = {
@@ -874,7 +874,7 @@ d_vastergotland = {
 	}
 	
 	1318.2.16 = {
-		liege = "k_sweden" # Duke Erik dies at Nyköpingshus
+		liege = "k_sweden" # Duke Erik dies at NykÃ¶pingshus
 		holder = 450504 # King Birger
 	}
 	
@@ -920,10 +920,10 @@ c_vastergotland = {
 	holder = 100521 # Ragnvald
 }
 1020.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1028.1.12 = {
 	holder = 100522 # Stenkil
@@ -935,7 +935,7 @@ c_vastergotland = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -947,7 +947,7 @@ c_vastergotland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -1004,10 +1004,10 @@ c_skara = {
 	holder = 100521 # Ragnvald
 }
 1020.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1028.1.12 = {
 	holder = 100522 # Stenkil
@@ -1019,7 +1019,7 @@ c_skara = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -1031,7 +1031,7 @@ c_skara = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -1058,19 +1058,19 @@ c_skara = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1284.1.1 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -1125,10 +1125,10 @@ c_dal = {
 	holder = 100521 # Ragnvald
 }
 1020.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1028.1.12 = {
 	holder = 100522 # Stenkil
@@ -1147,7 +1147,7 @@ c_dal = {
 	liege = k_sweden
 	holder = 200010
 }
-## Lilliehöök ancestors
+## LilliehÃ¶Ã¶k ancestors
 1200.1.1 = {
 	holder = 194247
 }
@@ -1210,16 +1210,16 @@ c_varmland = {
 1020.1.2 = {
 	liege = k_sweden
 	de_jure_liege = d_bergslagen
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
 }
 1064.1.1 = {
-	holder = 102523 # Håkon Ivarson
+	holder = 102523 # HÃ¥kon Ivarson
 }
 1081.1.2 = {
 	holder = 102525
@@ -1231,7 +1231,7 @@ c_varmland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -1243,7 +1243,7 @@ c_varmland = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -1267,19 +1267,19 @@ c_varmland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1284.1.1 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -1290,7 +1290,7 @@ c_varmland = {
 	holder = 450501 # Erik Magnusson
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Erik dies at Nyköpingshus
+	liege = k_sweden # Duke Erik dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1319.7.8 = {
@@ -1326,16 +1326,16 @@ c_nordmark = {
 1020.1.2 = {
 	liege = k_sweden
 	de_jure_liege = d_bergslagen
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
 }
 1064.1.1 = {
-	holder = 102523 # Håkon Ivarson
+	holder = 102523 # HÃ¥kon Ivarson
 }
 1081.1.2 = {
 	holder = 102525
@@ -1347,7 +1347,7 @@ c_nordmark = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -1359,7 +1359,7 @@ c_nordmark = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -1383,19 +1383,19 @@ c_nordmark = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1284.1.1 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -1406,7 +1406,7 @@ c_nordmark = {
 	holder = 450501 # Erik Magnusson
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Erik dies at Nyköpingshus
+	liege = k_sweden # Duke Erik dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1319.7.8 = {
@@ -1472,7 +1472,7 @@ d_ostergotland = {
 	liege = 0
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Erik dies at Nyköpingshus
+	liege = k_sweden # Duke Erik dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1319.7.8 = {
@@ -1510,7 +1510,7 @@ c_ostergotland = {
 	holder = 41257 # Rikulfr Ylfing
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 935.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -1520,10 +1520,10 @@ c_ostergotland = {
 }
 970.1.1 = {
 	liege = k_sweden
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.1 = {
 	liege = d_ostergotland
@@ -1581,7 +1581,7 @@ c_kinda = {
 	holder = 41257 # Rikulfr Ylfing
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 935.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -1591,10 +1591,10 @@ c_kinda = {
 }
 970.1.1 = {
 	liege = k_sweden
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.1 = {
 	liege = d_ostergotland
@@ -1662,13 +1662,13 @@ c_narke = {
 	holder = 100502
 }
 970.1.1 = {
-	holder = 100504 # Erik Segersäll
+	holder = 100504 # Erik SegersÃ¤ll
 }
 995.1.2 = {
-	holder = 100506 # Olof Skötkonung
+	holder = 100506 # Olof SkÃ¶tkonung
 }
 1022.1.7 = {
-	holder = 100508 # Anund Jakob "Kolbränna"
+	holder = 100508 # Anund Jakob "KolbrÃ¤nna"
 }
 1050.1.16 = {
 	holder = 100509 # Emund den Gamle, aka "Emund Slemme"
@@ -1684,7 +1684,7 @@ c_narke = {
 	holder = 100523 # Halsten
 }
 1070.12.1 = {
-	holder = 100526 # Håkan Röde
+	holder = 100526 # HÃ¥kan RÃ¶de
 }
 1080.12.1 = {
 	holder = 100524 # Inge the Older
@@ -1742,7 +1742,7 @@ c_gutland = {
 	holder = 1234017 # Eirikr av Visborg
 }
 1000.1.1 = {
-	holder = 1234018 # Björn av Visborg
+	holder = 1234018 # BjÃ¶rn av Visborg
 }
 # republic of Gotland
 1020.1.1 = {
@@ -1787,7 +1787,7 @@ c_gutland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -1799,7 +1799,7 @@ c_gutland = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -1838,19 +1838,19 @@ c_gutland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -1869,12 +1869,12 @@ d_smaland = {
 970.1.1 = {
 	de_jure_liege = k_sweden
 }
-	# Duchy of Småland
+	# Duchy of SmÃ¥land
 	860.1.1 = {
 		holder = 41266 # Fictional local chief
 		government = tribal_government
 	}
-# Duchy of Småland
+# Duchy of SmÃ¥land
 
 875.1.1 = {
 	holder = 0
@@ -1904,12 +1904,12 @@ c_more = {
 }
 964.1.1 = {
 
-	holder = 1234019 # Vagn Möring
+	holder = 1234019 # Vagn MÃ¶ring
 }
 1003.1.1 = {
 
 	liege = k_sweden
-	holder = 1234020 # Ulfr Möring
+	holder = 1234020 # Ulfr MÃ¶ring
 }
 1022.1.1 = {
 	liege = d_ostergotland
@@ -1936,7 +1936,7 @@ c_more = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -1972,7 +1972,7 @@ c_more = {
 	holder = 450607 # Valdemar Magnusson
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Valdemar dies at Nyköpingshus
+	liege = k_sweden # Duke Valdemar dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1320.1.1 = {
@@ -1997,12 +1997,12 @@ c_sevede = {
 }
 964.1.1 = {
 
-	holder = 1234019 # Vagn Möring
+	holder = 1234019 # Vagn MÃ¶ring
 }
 1003.1.1 = {
 
 	liege = k_sweden
-	holder = 1234020 # Ulfr Möring
+	holder = 1234020 # Ulfr MÃ¶ring
 }
 1022.1.1 = {
 	liege = d_ostergotland
@@ -2029,7 +2029,7 @@ c_sevede = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2065,7 +2065,7 @@ c_sevede = {
 	holder = 450607 # Valdemar Magnusson
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Valdemar dies at Nyköpingshus
+	liege = k_sweden # Duke Valdemar dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1320.1.1 = {
@@ -2077,27 +2077,27 @@ c_sevede = {
 
 c_varend = {
 
-# Värend (formerly Småland)
+# VÃ¤rend (formerly SmÃ¥land)
 860.1.1 = {
 	holder = 41266 # Fictional local chief
 }
 926.1.1 = {
 	holder = 260562 # Fictional local chief
 }
-968.1.1 = { # Pretty weak, if even any connection between Småland and Uppland or Götaland
+968.1.1 = { # Pretty weak, if even any connection between SmÃ¥land and Uppland or GÃ¶taland
 
-	holder = 1234016 # Kol Värending
+	holder = 1234016 # Kol VÃ¤rending
 }
 1005.1.1 = {
-	holder = 1234015 # Toke Värending
+	holder = 1234015 # Toke VÃ¤rending
 }
 1027.1.1 = {
-	holder = 1234007 # Kol Värending
+	holder = 1234007 # Kol VÃ¤rending
 }
 1048.1.1 = {
 	
 	liege = k_sweden
-	holder = 20020 # Toke Värending
+	holder = 20020 # Toke VÃ¤rending
 }
 1090.1.1 = {
 	holder = 100524 # Inge the Older
@@ -2109,7 +2109,7 @@ c_varend = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2121,7 +2121,7 @@ c_varend = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2145,19 +2145,19 @@ c_varend = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -2180,27 +2180,27 @@ c_varend = {
 
 c_njudung = {
 
-# Värend (formerly Småland)
+# VÃ¤rend (formerly SmÃ¥land)
 860.1.1 = {
 	holder = 41266 # Fictional local chief
 }
 926.1.1 = {
 	holder = 260562 # Fictional local chief
 }
-968.1.1 = { # Pretty weak, if even any connection between Småland and Uppland or Götaland
+968.1.1 = { # Pretty weak, if even any connection between SmÃ¥land and Uppland or GÃ¶taland
 
-	holder = 1234016 # Kol Värending
+	holder = 1234016 # Kol VÃ¤rending
 }
 1005.1.1 = {
-	holder = 1234015 # Toke Värending
+	holder = 1234015 # Toke VÃ¤rending
 }
 1027.1.1 = {
-	holder = 1234007 # Kol Värending
+	holder = 1234007 # Kol VÃ¤rending
 }
 1048.1.1 = {
 	
 	liege = k_sweden
-	holder = 20020 # Toke Värending
+	holder = 20020 # Toke VÃ¤rending
 }
 1090.1.1 = {
 	holder = 100524 # Inge the Older
@@ -2212,7 +2212,7 @@ c_njudung = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2224,7 +2224,7 @@ c_njudung = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2248,19 +2248,19 @@ c_njudung = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -2292,20 +2292,20 @@ c_finnveden = {
 926.1.1 = {
 	holder = 260562 # Fictional local chief
 }
-968.1.1 = { # Pretty weak, if even any connection between Småland and Uppland or Götaland
+968.1.1 = { # Pretty weak, if even any connection between SmÃ¥land and Uppland or GÃ¶taland
 
-	holder = 1234016 # Kol Värending
+	holder = 1234016 # Kol VÃ¤rending
 }
 1005.1.1 = {
-	holder = 1234015 # Toke Värending
+	holder = 1234015 # Toke VÃ¤rending
 }
 1027.1.1 = {
-	holder = 1234007 # Kol Värending
+	holder = 1234007 # Kol VÃ¤rending
 }
 1048.1.1 = {
 
 	liege = k_sweden
-	holder = 20020 # Toke Värending
+	holder = 20020 # Toke VÃ¤rending
 }
 1090.1.1 = {
 	holder = 100524 # Inge the Older
@@ -2317,7 +2317,7 @@ c_finnveden = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2329,7 +2329,7 @@ c_finnveden = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2353,19 +2353,19 @@ c_finnveden = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -2401,10 +2401,10 @@ c_oland = {
 }
 964.1.1 = {
 
-	holder = 1234019 # Vagn Möring
+	holder = 1234019 # Vagn MÃ¶ring
 }
 1003.1.1 = {
-	holder = 1234020 # Ulfr Möring
+	holder = 1234020 # Ulfr MÃ¶ring
 }
 1022.1.1 = {
 
@@ -2428,7 +2428,7 @@ c_oland = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2464,7 +2464,7 @@ c_oland = {
 	holder = 450607 # Valdemar Magnusson
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Valdemar dies at Nyköpingshus
+	liege = k_sweden # Duke Valdemar dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1320.1.1 = {
@@ -2498,7 +2498,7 @@ c_gastrikland = {
 	holder = 163108
 }
 920.1.1 = {
-	holder = 260553 # Ring Björnsson, semi-legendary petty-King of Sweden/Uppland
+	holder = 260553 # Ring BjÃ¶rnsson, semi-legendary petty-King of Sweden/Uppland
 }
 940.1.1 = {
 	holder = 163107 # Eirik Ringsson, semi-legendary petty-King of Sweden/Uppland
@@ -2535,7 +2535,7 @@ c_gastrikland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2547,7 +2547,7 @@ c_gastrikland = {
 	holder = 200490 # Erik "the Holy"
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -2572,19 +2572,19 @@ c_gastrikland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -2646,7 +2646,7 @@ c_halsingland = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2722,7 +2722,7 @@ c_medelpad = {
 	holder = 100551 # Inge the Younger, son of 100523 (Halsten)
 }
 1125.6.6 = {
-	holder = 100552 # Ragnvald "Knaphövde", possibly a son of 100524 (Inge the Older)
+	holder = 100552 # Ragnvald "KnaphÃ¶vde", possibly a son of 100524 (Inge the Older)
 }
 1126.6.6 = {
 	holder = 101531 # Magnus Nilsson, son of Danish King Nils and Inge the Older's daughter Margareta
@@ -2794,19 +2794,19 @@ c_angermanland = {
 }
 1229.1.1 = {
 	liege = k_sweden
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -2834,9 +2834,6 @@ d_gotland = {
 	}
 
 500.1.1 = {
-	de_jure_liege = k_geats
-}
-970.1.1 = {
 	de_jure_liege = k_sweden
 }
 1020.1.1 = {
@@ -2914,10 +2911,10 @@ k_denmark = {
 		holder = 101500 # Gorm the Old
 	}
 	958.12.1 = {
-		holder = 101502 # Harald Blåtand
+		holder = 101502 # Harald BlÃ¥tand
 	}
 	986.11.1 = {
-		holder = 101505 # Svend Tveskägg
+		holder = 101505 # Svend TveskÃ¤gg
 	}
 	1014.2.3 = {
 		holder = 101507 # Harald II
@@ -3013,7 +3010,7 @@ d_sjaelland = {
 #	holder = 163109
 #}
 860.1.1 = {
-	holder = 163110 # Sigurd Ormeøje
+	holder = 163110 # Sigurd OrmeÃ¸je
 }
 917.1.1 = {
 	#holder = 0
@@ -3060,17 +3057,17 @@ c_sjaelland = { #Probably should be broken into 2 counties
 }
 915.1.1 = {
 	liege = d_skane
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 938.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 961.1.1 = {
 	liege = k_denmark
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -3103,7 +3100,7 @@ c_sjaelland = { #Probably should be broken into 2 counties
 	holder = 101530 # Nils Svendsen
 }
 1126.1.1 = {
-	holder = 1227852 # Peder Bodilsen, biggest landholder in southern Sjælland.
+	holder = 1227852 # Peder Bodilsen, biggest landholder in southern SjÃ¦lland.
 }
 1146.8.27 = {
     liege=d_sjaelland
@@ -3183,7 +3180,7 @@ c_fyn = {
 	holder = 101533 # Thorgil Sprakalegg, is recorded as a chieftain
 }
 1001.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -3265,17 +3262,17 @@ c_lolland_falster = {
 }
 915.1.1 = {
 	liege = d_skane
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 938.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 961.1.1 = {
 	liege = k_denmark
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -3291,7 +3288,7 @@ c_lolland_falster = {
 	holder = 102529 # Magnus den Gode
 }
 1047.10.25 = {
-	holder = 101536 # Asbjørn Ulfsøn. Jarl domain unspecified, but it wasn't of Halland or Northern Jylland, so that leaves either Sønderjylland and Lolland.
+	holder = 101536 # AsbjÃ¸rn UlfsÃ¸n. Jarl domain unspecified, but it wasn't of Halland or Northern Jylland, so that leaves either SÃ¸nderjylland and Lolland.
 }
 1086.1.1 = {
 	holder = 101519 # Knud den Helige
@@ -3307,13 +3304,13 @@ c_lolland_falster = {
 }
 ###Jarls of Lolland
 1117.1.1 = {
-	holder = 1227872 # Ulf/Ubbe Esbernsen/Asbjørnsen jarl of Lolland 1117-1133
+	holder = 1227872 # Ulf/Ubbe Esbernsen/AsbjÃ¸rnsen jarl of Lolland 1117-1133
 }
 1133.1.1 = {
 	holder = 201517 # Erik Emune Jarl of Lolland 1133-1134
 }
 1134.6.25 = {
-	holder = 1227854 # Jørgen Bodilsen, jarl of Smålandene(aka both Lolland, Als, Møn and Falster) 1134-?
+	holder = 1227854 # JÃ¸rgen Bodilsen, jarl of SmÃ¥landene(aka both Lolland, Als, MÃ¸n and Falster) 1134-?
 }
 1160.8.2 = {
 	holder = 30551 # Prislaw youngest son Niklot, Jarl of Lolland and Als 1060-1067
@@ -3321,9 +3318,9 @@ c_lolland_falster = {
 1167.1.1 = {
 	holder = 30553 # Knud Prislawsen Jarl of Lolland and Als 1167-1183
 }
-###Ørn/Due/Glob
+###Ã˜rn/Due/Glob
 1183.11.6 = {
-	holder = 1227860 # Peder Nielsen Ørn
+	holder = 1227860 # Peder Nielsen Ã˜rn
 }
 1185.1.1 = {
 	holder = 1227861 # Alexander Pedersen Falster
@@ -3331,11 +3328,11 @@ c_lolland_falster = {
 1221.1.1 = {
 	holder = 1227864 # Niels Alexandersen
 }
-###Gøye
+###GÃ¸ye
 1262.1.1 = {
-	holder = 1227877 # Mathias til Flårup
+	holder = 1227877 # Mathias til FlÃ¥rup
 }
-###Ørn/Due/Glob
+###Ã˜rn/Due/Glob
 1268.1.1 = {
 	holder = 1227864 # Niels Alexandersen
 }
@@ -3360,34 +3357,34 @@ d_skane = {
 
 # Kings of Eastern Denmark
 860.1.1 = {
-	holder = 168633 # Sigfred Haraldsen(Harald-Klak), king of eastern Denmark/Skåne
+	holder = 168633 # Sigfred Haraldsen(Harald-Klak), king of eastern Denmark/SkÃ¥ne
 	government = tribal_government
 }
 885.1.1 = {
-	holder = 168634 # Harald(Klak-Harald) Sigfredsen, king of eastern Denmark/Skåne
+	holder = 168634 # Harald(Klak-Harald) Sigfredsen, king of eastern Denmark/SkÃ¥ne
 }
 915.1.1 = {
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 938.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 # Jarls of Eastern Denmark/Skaane
 961.1.1 = {
 	liege = k_denmark
-	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of Skåne
+	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of SkÃ¥ne
 }
 985.1.1 = {
-	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of Skåne
+	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of SkÃ¥ne
 }
 1025.1.1 = {
-	holder = 168642 # Harald Torgilsen Jarl of Skåne
+	holder = 168642 # Harald Torgilsen Jarl of SkÃ¥ne
 	government = feudal_government
 }
 1042.1.1 = {
-	holder = 168643 # Torgils Haraldsen Jarl of Skåne
+	holder = 168643 # Torgils Haraldsen Jarl of SkÃ¥ne
 }
-# Male line of the east royal Hildetan æt dies out and the Jarldom reverts too the crown
+# Male line of the east royal Hildetan Ã¦t dies out and the Jarldom reverts too the crown
 1069.1.1 = {
 	holder = 101515 # Svend Estridsen
 }
@@ -3468,30 +3465,30 @@ c_skane = {
 
 860.1.1 = {
 	liege = d_skane
-	holder = 168633 # Sigfred Haraldsen(Harald-Klak), king of eastern Denmark/Skåne
+	holder = 168633 # Sigfred Haraldsen(Harald-Klak), king of eastern Denmark/SkÃ¥ne
 	government = tribal_government
 }
 885.1.1 = {
-	holder = 168634 # Harald(Klak-Harald) Sigfredsen, king of eastern Denmark/Skåne
+	holder = 168634 # Harald(Klak-Harald) Sigfredsen, king of eastern Denmark/SkÃ¥ne
 }
 915.1.1 = {
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 938.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 961.1.1 = {
-	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of Skåne
+	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of SkÃ¥ne
 }
 985.1.1 = {
-	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of Skåne
+	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of SkÃ¥ne
 }
 1025.1.1 = {
-	holder = 168642 # Harald Torgilsen Jarl of Skåne
+	holder = 168642 # Harald Torgilsen Jarl of SkÃ¥ne
 	government = feudal_government
 }
 1042.1.1 = {
-	holder = 168643 # Torgils Haraldsen Jarl of Skåne
+	holder = 168643 # Torgils Haraldsen Jarl of SkÃ¥ne
 }
 1069.1.1 = {
 	liege = k_denmark
@@ -3568,19 +3565,19 @@ c_halland = {
 	holder = 6843
 }
 915.1.1 = {
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 935.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 961.1.1 = {
-	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of Skåne
+	holder = 168639 # Harald(Strut-Harald) Sigfredsen Jarl of SkÃ¥ne
 }
 985.1.1 = {
-	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of Skåne
+	holder = 168641 # Torgil(the Tall) Haraldsen Jarl of SkÃ¥ne
 }
 1025.1.1 = {
-	holder = 168642 # Harald Torgilsen Jarl of Skåne
+	holder = 168642 # Harald Torgilsen Jarl of SkÃ¥ne
 }
 1042.1.1 = {
 	liege = d_jylland
@@ -3593,7 +3590,7 @@ c_halland = {
 	holder = 102504 # Finn Arneson of Norway
 }
 1062.1.1 = {
-	holder = 102523 # Håkon Ivarson
+	holder = 102523 # HÃ¥kon Ivarson
 }
 1063.1.1 = {
 	holder = 101515
@@ -3699,7 +3696,7 @@ d_bornholm = {
 	holder = 1144484 # Sigurd Kappe/Kaabe son of Vesete, jarl of Bornholm 986ish-?
 }
 1025.1.1 = {
-	holder = 1144488 # Kåbe-Svend Jarl of Bornholm ?
+	holder = 1144488 # KÃ¥be-Svend Jarl of Bornholm ?
 }
 1060.1.1 = {
 	holder = 0
@@ -3716,10 +3713,10 @@ c_bornholm = {
 }
 915.1.1 = {
 	liege = d_skane
-	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/Skåne
+	holder = 168635 # Gorm Haraldsen(Klak-Harald), king of eastern Denmark/SkÃ¥ne
 }
 938.1.1 = {
-	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/Skåne
+	holder = 168638 # Sigfred/Sigvald Gormsen, king of eastern Denmark/SkÃ¥ne
 }
 947.1.1 = {
 	holder = 1144483 # Vesete Jarl of Bornholm. ?-980ish
@@ -3736,7 +3733,7 @@ c_bornholm = {
 	holder = 1144484 # Sigurd Kappe/Kaabe son of Vesete, jarl of Bornholm 986ish-?
 }
 1025.1.1 = {
-	holder = 1144488 # Kåbe-Svend Jarl of Bornholm ?
+	holder = 1144488 # KÃ¥be-Svend Jarl of Bornholm ?
 }
 1060.1.1 = {
 	holder = 101546
@@ -3821,10 +3818,10 @@ c_blekinge = {
 1025.1.1 = {
 
 	liege = d_skane
-	holder = 168642 # Harald Torgilsen Jarl of Skåne
+	holder = 168642 # Harald Torgilsen Jarl of SkÃ¥ne
 }
 1042.1.1 = {
-	holder = 168643 # Torgils Haraldsen Jarl of Skåne
+	holder = 168643 # Torgils Haraldsen Jarl of SkÃ¥ne
 }
 1066.1.1 = {
 	liege = k_denmark
@@ -3892,7 +3889,7 @@ c_blekinge = {
 
 d_jylland = {
 	852.1.1 = {
-		holder = 6866 # Hårik II
+		holder = 6866 # HÃ¥rik II
 		government = tribal_government
 	}
 865.1.1 = {
@@ -3905,13 +3902,13 @@ d_jylland = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 961.1.1 = {
 	liege = k_denmark
 }
 986.11.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -3936,7 +3933,7 @@ d_jylland = {
 	holder = 101541 # Ulf Galica
 }
 1062.1.1 = {
-	holder = 101542 # Thrugot Ulfssøn
+	holder = 101542 # Thrugot UlfssÃ¸n
 }
 1070.4.28 = {
 	holder = 0
@@ -3978,10 +3975,10 @@ c_aarhus = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.11.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4090,13 +4087,13 @@ c_viborg = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 980.1.1 = {
 	holder = 101533 # Thorgil Sprakalegg, is recorded as a chieftain. Putting him in Jutland to get some vassals in Jutland
 }
 1001.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4198,13 +4195,13 @@ c_ringkobing = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 980.1.1 = {
 	holder = 101533 # Thorgil Sprakalegg, is recorded as a chieftain. Putting him in Jutland to get some vassals in Jutland
 }
 1001.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4306,10 +4303,10 @@ c_aalborg = {
 	liege = d_jylland
 }
 936.1.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4328,11 +4325,11 @@ c_aalborg = {
 	liege = d_jylland
 }
 1062.1.1 = {
-	holder = 101542 # Thrugot Ulfssøn
+	holder = 101542 # Thrugot UlfssÃ¸n
 }
 1070.4.28 = {
 	liege = k_denmark
-	holder = 151000 # Svend Thrugotsøn
+	holder = 151000 # Svend ThrugotsÃ¸n
 }
 1086.1.1 = {
 	holder = 151002 # Christiern Thrugotsen
@@ -4395,7 +4392,7 @@ d_slesvig = {
 	government = tribal_government
 }
 856.1.1 = {
-	holder = 6866 # Hårik II
+	holder = 6866 # HÃ¥rik II
 }
 865.1.1 = {
 	holder = 1144478 # Oskitlel
@@ -4488,7 +4485,7 @@ c_slesvig = {
 	holder = 1144491 # Howi jarl of southern jutland.
 }
 856.1.1 = {
-	holder = 6866 # Hårik II
+	holder = 6866 # HÃ¥rik II
 }
 865.1.1 = {
 	holder = 1144471
@@ -4498,16 +4495,16 @@ c_slesvig = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.11.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 991.1.1 = {
 	holder = 1144481 # Heming, son of Strut-Harald, Earl of Hedeby
 }
 1014.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 	government = feudal_government
 }
 1014.2.3 = {
@@ -4592,7 +4589,7 @@ c_vorbasse = {
 	holder = 1144491 # Howi jarl of southern jutland.
 }
 856.1.1 = {
-	holder = 6866 # Hårik II
+	holder = 6866 # HÃ¥rik II
 }
 865.1.1 = {
 	holder = 1144478 # Oskitlel
@@ -4602,13 +4599,13 @@ c_vorbasse = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 980.1.1 = {
 	holder = 101533 # Thorgil Sprakalegg, is recorded as a chieftain. Putting him in Jutland to get some vassals in Jutland
 }
 1001.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4696,7 +4693,7 @@ c_ribe = {
 	holder = 1144491 # Howi jarl of southern jutland.
 }
 856.1.1 = {
-	holder = 6866 # Hårik II
+	holder = 6866 # HÃ¥rik II
 }
 865.1.1 = {
 	holder = 1144478 # Oskitlel
@@ -4706,16 +4703,16 @@ c_ribe = {
 	holder = 101500 # Gorm the Old
 }
 958.12.1 = {
-	holder = 101502 # Harald Blåtand
+	holder = 101502 # Harald BlÃ¥tand
 }
 986.11.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 991.1.1 = {
 	holder = 1144481 # Heming, son of Strut-Harald, Earl of Hedeby
 }
 1014.1.1 = {
-	holder = 101505 # Svend Tveskägg
+	holder = 101505 # Svend TveskÃ¤gg
 }
 1014.2.3 = {
 	holder = 101507 # Harald II
@@ -4852,9 +4849,9 @@ c_kiel = {
 }
 1203.1.1 = {
 	liege = d_holstein
-	holder = 1603135 # Timmo II von Segeberg, Overbode and voigt of Segeberg under Valdemar and Albrecht von Weimar-Orlamünde
+	holder = 1603135 # Timmo II von Segeberg, Overbode and voigt of Segeberg under Valdemar and Albrecht von Weimar-OrlamÃ¼nde
 }
-#Battle of Mölln
+#Battle of MÃ¶lln
 1225.1.1 = {
 	holder = 1603170 # Gottschalk von Segeberg, Overbode of Holstein and Wagrien 1225-1248
 }
@@ -4873,7 +4870,7 @@ c_kiel = {
 	holder = 31755 # Johann II von Schauenburg the One-Eyed, the third count of Holstein-Kiel. Was deposed in 1316
 }
 1316.1.1 = {
-	holder = 451960 # Johann III von Schauenburg, count of Holstein-Plön. Inherited both Holstein-Kiel and Holstein-Segeburg after Johann II was deposed
+	holder = 451960 # Johann III von Schauenburg, count of Holstein-PlÃ¶n. Inherited both Holstein-Kiel and Holstein-Segeburg after Johann II was deposed
 }
 
 }
@@ -4963,21 +4960,21 @@ c_lubeck = {
 	liege = d_holstein
 	holder = 212360 # Adolf III von Schauenburg, third Count of Holstein
 }
-#Lübeck submit to Danish rule after the defeat of Adolf III.
+#LÃ¼beck submit to Danish rule after the defeat of Adolf III.
 1203.1.1 = {
 	holder = 1603108 # Hugo von Hildesheim(von Werder), Vogt and biggest magante during the pre Hanse area. Also son in law of Marcrad II.
 }
-#Lübeck revolts from Danish rule in 1225, following Valdemar's capture in 1223
-#Peace treaty after the battle of Mölln
+#LÃ¼beck revolts from Danish rule in 1225, following Valdemar's capture in 1223
+#Peace treaty after the battle of MÃ¶lln
 1225.11.17 = {
 	holder = 31752 # Adolf IV von Schauenburg, fourth Count of Holstein
 }
-#Lübeck sack the count's castle(the later Borgkloster) to halt his influence from strangling the chance of a republic.
+#LÃ¼beck sack the count's castle(the later Borgkloster) to halt his influence from strangling the chance of a republic.
 1226.6.1 = {
     liege=e_hre
 	holder = 1603108 # Hugo von Hildesheim
 }
-#Lübeck gains imperial intermediacy, Hansa established
+#LÃ¼beck gains imperial intermediacy, Hansa established
 1227.1.1 = {
 	liege = k_hansa
 	holder = 167102 # Gottschalk von Bardewik
@@ -4995,7 +4992,7 @@ c_lubeck = {
 	holder = 167220 # Dietrich Vorrade
 }
 1291.1.1 = {
-	holder = 167237 # Alexander Lüneburg
+	holder = 167237 # Alexander LÃ¼neburg
 }
 1303.1.1 = {
 	holder = 167104 # Albrecht von Bardewik
@@ -5024,7 +5021,7 @@ c_lubeck = {
 
 b_eutin = {
 	# Imperial Free City - seed of the Hansa
-	# Mayors of Lübeck
+	# Mayors of LÃ¼beck
 	1227.1.1 = {
 		holder = 167102 #Gottschalk von Bardewik
 	}
@@ -5041,7 +5038,7 @@ b_eutin = {
 		holder = 167220 #Dietrich Vorrade
 	}
 	1291.1.1 = {
-		holder = 167237 #Alexander Lüneburg
+		holder = 167237 #Alexander LÃ¼neburg
 	}
 	1303.1.1 = {
 		holder = 167104 #Albrecht von Bardewik
@@ -5327,7 +5324,7 @@ k_norway = {
 		holder = 102529 #Magnus the Good
 	}
 	1047.10.25 = {
-		holder = 102531 # Harald Hardråde
+		holder = 102531 # Harald HardrÃ¥de
 		succession_laws = { scandinavian_elective_succession_law }
 	}
 	1066.9.26 = {
@@ -5337,7 +5334,7 @@ k_norway = {
 		holder = 102534 # Olof Haraldson
 	}
 	1093.1.1 = {
-		holder = 102577 # Håkon Magnuson
+		holder = 102577 # HÃ¥kon Magnuson
 	}
 	1094.6.6 = {
 		holder = 202511 # Magnus Barfot
@@ -5351,7 +5348,7 @@ k_norway = {
 		}
 	}
 	1115.12.22 = {
-		holder = 222597 # Øystein Magnusson
+		holder = 222597 # Ã˜ystein Magnusson
 	}
 	1123.8.29 = {
 		holder = 222595 # Sigurd Magnusson
@@ -5366,13 +5363,13 @@ k_norway = {
 		holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 	}
 	1155.6.10 = {
-		holder = 202514 # Øystein, son of Harald Gille
+		holder = 202514 # Ã˜ystein, son of Harald Gille
 	}
 	1157.8.21 = {
 		holder = 202512 # Inge Krokrygg, son of Harald Gille
 	}
 	1161.1.5 = {
-		holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+		holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 	}
 	1162.7.7 = {
 		holder = 202051 # Magnus Erlingsson
@@ -5381,28 +5378,28 @@ k_norway = {
 		holder = 202500 # Sverre Sigurdsson
 	}
 	1202.3.9 = {
-		holder = 202502 # Håkon Sverreson
+		holder = 202502 # HÃ¥kon Sverreson
 	}
 	1204.1.1 = {
 		holder = 202508 # Guttorm Sigurdsson
 	}
 	1204.8.11 = {
-		holder = 202032 # Inge Bårdsson
+		holder = 202032 # Inge BÃ¥rdsson
 	}
 	1217.4.23 = {
-		holder = 202509 # Håkon Håkonsson
+		holder = 202509 # HÃ¥kon HÃ¥konsson
 		effect = {
 			set_capital_county = title:c_hordalandi
 		}
 	}
 	1263.12.15 = {
-		holder = 6905 # Magnus Lagaböter
+		holder = 6905 # Magnus LagabÃ¶ter
 	}
 	1280.5.9 = {
-		holder = 6906 # Erik 'Prästhatare' Magnusson
+		holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 	}
 	1299.7.15 = {
-		holder = 452510 # Håkon Magnusson
+		holder = 452510 # HÃ¥kon Magnusson
 	}
 	1314.1.1 = {
 		effect = {
@@ -5410,9 +5407,9 @@ k_norway = {
 		}
 	}
 	1319.5.8 = {
-		holder = 450500 # Magnus Eriksson (Bjälbo)
+		holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 	}
-	# 1343.11.18 Håkon Magnusson
+	# 1343.11.18 HÃ¥kon Magnusson
 
 }
 
@@ -5452,28 +5449,28 @@ d_viken = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 
 
@@ -5516,7 +5513,7 @@ c_raniriki = {
 }
 1000.1.1 = {
 	liege = d_trandalog
-	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, Jämtland and Møre in the settlement following the Battle of Svolder
+	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, JÃ¤mtland and MÃ¸re in the settlement following the Battle of Svolder
 }
 1015.1.1 = {
 	liege = k_norway
@@ -5526,7 +5523,7 @@ c_raniriki = {
 	holder = 102518 # Haakon Eiriksson of the Lade Family
 }
 1030.7.29 = {
-	holder = 101514 # Svein Knutsson, son of Canute the Great and Ælfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
+	holder = 101514 # Svein Knutsson, son of Canute the Great and Ã†lfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
 }
 1035.1.1 = {
 	holder = 1228069
@@ -5541,7 +5538,7 @@ c_raniriki = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -5563,13 +5560,13 @@ c_raniriki = {
 	holder = 144250
 }
 1274.1.1 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1312.1.1 = {
 	liege = d_ostergotland
@@ -5625,13 +5622,13 @@ c_vingulmork = {
 	holder = 102518 # Haakon Eiriksson of the Lade Family
 }
 1030.7.29 = {
-	holder = 101514 # Svein Knutsson, son of Canute the Great and Ælfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
+	holder = 101514 # Svein Knutsson, son of Canute the Great and Ã†lfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
 }
 1035.1.1 = {
 	holder = 102529 # Magnus the Good
 }
 1047.10.25 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.1.1 = {
 	holder = 102534
@@ -5643,7 +5640,7 @@ c_vingulmork = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -5665,28 +5662,28 @@ c_vingulmork = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 
 }
@@ -5718,7 +5715,7 @@ c_vestfold = {
 	liege = k_norway
 }
 927.1.1 = {
-	holder = 144006 # Gudrödr Björnsson, Petty-King in the Westfold, father of Harald Grenske
+	holder = 144006 # GudrÃ¶dr BjÃ¶rnsson, Petty-King in the Westfold, father of Harald Grenske
 }
 961.1.1 = {
 	holder = 102508 # Harald Greycloak
@@ -5763,7 +5760,7 @@ c_vestfold = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -5788,28 +5785,28 @@ c_vestfold = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 
 }
@@ -5839,20 +5836,20 @@ c_telemark = {
 900.1.1 = {
 	holder = 1228001 # Aasgrim Gylde
 }
-# claimed by Harald, and handed to Bjørn. Linked with Vestfold from here.
+# claimed by Harald, and handed to BjÃ¸rn. Linked with Vestfold from here.
 925.1.1 = {
-	holder = 144005 # Bjørn Farmann
+	holder = 144005 # BjÃ¸rn Farmann
 }
 927.1.1 = {
 	holder = 144002 # Olaf Haraldsson Geirstadalf
 }
 934.1.1 = {
 	liege = k_norway
-	holder = 144006 # Gudrød Bjørnsson
+	holder = 144006 # GudrÃ¸d BjÃ¸rnsson
 }
 # Vestfold and Telemark reclaimed by the crown
 968.1.1 = {
-	holder = 102508 # Harald Gråfeld
+	holder = 102508 # Harald GrÃ¥feld
 }
 970.1.1 = {
 	liege = k_denmark
@@ -5872,7 +5869,7 @@ c_telemark = {
 	holder = 102518 # Haakon Eiriksson of the Lade Family
 }
 1030.7.29 = {
-	holder = 101514 # Svein Knutsson, son of Canute the Great and Ælfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
+	holder = 101514 # Svein Knutsson, son of Canute the Great and Ã†lfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
 }
 1034.1.1 = {
 	holder = 1228072 # Eiliv of Bratsberg
@@ -5887,7 +5884,7 @@ c_telemark = {
 	holder = 1290090 # Gregorius Dagsson of Bratsberg, Lendsmann
 }
 1161.1.7 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -5902,28 +5899,28 @@ c_telemark = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450740
@@ -5951,7 +5948,7 @@ c_nedenes = {
 }
 927.1.1 = {
 	liege = k_norway
-	holder = 144006 # Gudrödr Björnsson, Petty-King in the Westfold, father of Harald Grenske
+	holder = 144006 # GudrÃ¶dr BjÃ¶rnsson, Petty-King in the Westfold, father of Harald Grenske
 }
 961.1.1 = {
 	holder = 102508 # Harald Greycloak
@@ -5974,13 +5971,13 @@ c_nedenes = {
 	holder = 102518 # Haakon Eiriksson of the Lade Family
 }
 1030.7.29 = {
-	holder = 101514 # Svein Knutsson, son of Canute the Great and Ælfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
+	holder = 101514 # Svein Knutsson, son of Canute the Great and Ã†lfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
 }
 1035.1.1 = {
 	holder = 102529 # Magnus the Good
 }
 1047.10.25 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.1.1 = {
 	holder = 20016
@@ -5989,7 +5986,7 @@ c_nedenes = {
 	holder = 102534 # Olof Haraldson
 }
 1093.1.1 = {
-	holder = 102577 # Håkon Magnuson
+	holder = 102577 # HÃ¥kon Magnuson
 }
 1094.6.6 = {
 	holder = 202511 # Magnus Barfot
@@ -5998,7 +5995,7 @@ c_nedenes = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6013,13 +6010,13 @@ c_nedenes = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6034,28 +6031,28 @@ c_nedenes = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450780
@@ -6084,7 +6081,7 @@ c_agdeside = {
 }
 927.1.1 = {
 	liege = k_norway
-	holder = 144006 # Gudrödr Björnsson, Petty-King in the Westfold, father of Harald Grenske
+	holder = 144006 # GudrÃ¶dr BjÃ¶rnsson, Petty-King in the Westfold, father of Harald Grenske
 }
 961.1.1 = {
 	holder = 102508 # Harald Greycloak
@@ -6107,13 +6104,13 @@ c_agdeside = {
 	holder = 102518 # Haakon Eiriksson of the Lade Family
 }
 1030.7.29 = {
-	holder = 101514 # Svein Knutsson, son of Canute the Great and Ælfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
+	holder = 101514 # Svein Knutsson, son of Canute the Great and Ã†lfgifu. Ruled Norway alongside his mother as regent, after the death of Haakon Eiriksson of the Lade Earls at sea in 1029-30, thereby ending the family
 }
 1035.1.1 = {
 	holder = 102529 # Magnus the Good
 }
 1047.10.25 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.1.1 = {
 	holder = 20016
@@ -6122,7 +6119,7 @@ c_agdeside = {
 	holder = 102534 # Olof Haraldson
 }
 1093.1.1 = {
-	holder = 102577 # Håkon Magnuson
+	holder = 102577 # HÃ¥kon Magnuson
 }
 1094.6.6 = {
 	holder = 202511 # Magnus Barfot
@@ -6131,7 +6128,7 @@ c_agdeside = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6146,13 +6143,13 @@ c_agdeside = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6167,28 +6164,28 @@ c_agdeside = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450780
@@ -6224,10 +6221,10 @@ d_trondelag = {
 
 
 830.1.1 = {
-	holder = 186002 # Grjotgard Herlaugsson Jarl of lade and Håløy
+	holder = 186002 # Grjotgard Herlaugsson Jarl of lade and HÃ¥lÃ¸y
 }
 860.1.1 = {
-	holder = 186003 # Håkon Grjotgardsson Jarl of lade and Håløy
+	holder = 186003 # HÃ¥kon Grjotgardsson Jarl of lade and HÃ¥lÃ¸y
 }
 917.1.1 = {
 	liege = k_norway
@@ -6277,7 +6274,7 @@ d_trondelag = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6292,13 +6289,13 @@ d_trondelag = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6322,10 +6319,10 @@ d_trondelag = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450780
@@ -6390,7 +6387,7 @@ c_rogalandi = {
 	holder = 102534 # Olof Haraldson
 }
 1093.1.1 = {
-	holder = 102577 # Håkon Magnuson
+	holder = 102577 # HÃ¥kon Magnuson
 }
 1094.6.6 = {
 	holder = 202511 # Magnus Barfot
@@ -6399,7 +6396,7 @@ c_rogalandi = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6414,13 +6411,13 @@ c_rogalandi = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6435,31 +6432,31 @@ c_rogalandi = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1220.1.1 = {
 	holder = 194314
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450730
@@ -6532,13 +6529,13 @@ c_hordalandi = {
 	holder = 1290074 # Svein Erlendsson of Gjerde, Lord of Gjerde
 }
 1051.1.1 = {
-	holder = 183910 # Svein Sveinsson of Stødle, Lord of Stødle
+	holder = 183910 # Svein Sveinsson of StÃ¸dle, Lord of StÃ¸dle
 }
 1098.1.1 = {
-	holder = 183911 # Kyrpinga-Orm Sveinsson, Lord of Stødle and important Lendmann for Hordaland
+	holder = 183911 # Kyrpinga-Orm Sveinsson, Lord of StÃ¸dle and important Lendmann for Hordaland
 }
 1140.1.1 = {
-	holder = 202050 # Erling "Skakke" Ormsson, Lord of Stødle and Lendmann in Hordaland. Very Important noble
+	holder = 202050 # Erling "Skakke" Ormsson, Lord of StÃ¸dle and Lendmann in Hordaland. Very Important noble
 }
 1179.6.18 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6547,31 +6544,31 @@ c_hordalandi = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1220.1.1 = {
 	holder = 194314
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	liege = d_trondelag
@@ -6597,7 +6594,7 @@ c_sogn = {
 	
 
 820.1.1 = {
-	holder = 1228011 # Harald Guldskæg
+	holder = 1228011 # Harald GuldskÃ¦g
 }
 858.1.1 = {
 	holder = 1228022 # Atli the slender
@@ -6616,7 +6613,7 @@ c_sogn = {
 	holder = 1290096 # Thord Brynjulfsson, Lendmann of Aurland
 }
 952.1.1 = {
-	holder = 1290097 # Arinbjörn Herse
+	holder = 1290097 # ArinbjÃ¶rn Herse
 }
 970.1.1 = {
 	liege = d_trondelag
@@ -6646,7 +6643,7 @@ c_sogn = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6661,13 +6658,13 @@ c_sogn = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6676,28 +6673,28 @@ c_sogn = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	liege = d_trondelag
@@ -6727,10 +6724,10 @@ c_trandheim = {
 
 830.1.1 = {
 	liege = d_trondelag
-	holder = 186002 # Grjotgard Herlaugsson of Lade, Jarl of lade and Håløy
+	holder = 186002 # Grjotgard Herlaugsson of Lade, Jarl of lade and HÃ¥lÃ¸y
 }
 860.1.1 = {
-	holder = 186003 # Håkon Grjotgardsson of Lade, Jarl of lade and Håløy
+	holder = 186003 # HÃ¥kon Grjotgardsson of Lade, Jarl of lade and HÃ¥lÃ¸y
 }
 917.1.1 = {
 	holder = 1228055 # Sigurd Haakonsson of Lade, Jarl of Lade
@@ -6739,7 +6736,7 @@ c_trandheim = {
 	holder = 1228056 # Haakon Sigurdsson of Lade, Jarl of Lade
 }
 995.1.1 = {
-	holder = 1290111 # Olve of Egge, Pagan Chieftain in North Trøndelag
+	holder = 1290111 # Olve of Egge, Pagan Chieftain in North TrÃ¸ndelag
 }
 995.1.1 = {
 	liege = k_norway
@@ -6763,7 +6760,7 @@ c_trandheim = {
 	holder = 102529 # Magnus the Good
 }
 1047.1.1 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.9.26 = {
 	holder = 102532 # Magnus Haraldson
@@ -6772,7 +6769,7 @@ c_trandheim = {
 	holder = 102534 # Olof Haraldson
 }
 1093.1.1 = {
-	holder = 102577 # Håkon Magnuson
+	holder = 102577 # HÃ¥kon Magnuson
 }
 1094.6.6 = {
 	holder = 202511 # Magnus Barfot
@@ -6781,7 +6778,7 @@ c_trandheim = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -6796,13 +6793,13 @@ c_trandheim = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -6811,13 +6808,13 @@ c_trandheim = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
 	holder = 202034
@@ -6832,10 +6829,10 @@ c_trandheim = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450790
@@ -6851,20 +6848,20 @@ b_eynafylki = {	#Fictional, to allow character placement.
 d_trandalog = {
 
 800.1.1 = {
-	holder = 1228005 # Ivar Halvdansson mørekonge
+	holder = 1228005 # Ivar Halvdansson mÃ¸rekonge
 }
 825.1.1 = {
-	holder = 1228006 # Øystein Ivarsson mørekonge
+	holder = 1228006 # Ã˜ystein Ivarsson mÃ¸rekonge
 }
 858.1.1 = {
-	holder = 1228007 # Hundtjov Mørekonge
+	holder = 1228007 # Hundtjov MÃ¸rekonge
 }
 877.1.1 = {
-	holder = 0 # goes to the Mørejarls after the first battle of Solskjell
+	holder = 0 # goes to the MÃ¸rejarls after the first battle of Solskjell
 }
 1000.1.1 = {
 
-	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, Jämtland and Møre in the settlement following the Battle of Svolder
+	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, JÃ¤mtland and MÃ¸re in the settlement following the Battle of Svolder
 }
 1015.1.1 = {
 	
@@ -6927,22 +6924,22 @@ c_sunmore = {
 	holder = 102550 # Thorberg Arnesson of Giske
 }
 1028.1.22 = {
-	holder = 1228066 # Öysteinn Thorbergsson of Giske
+	holder = 1228066 # Ã–ysteinn Thorbergsson of Giske
 }
 1066.9.26 = {
 	holder = 102553 # Skofte Ogmundrsson of Giske
 }
 1103.1.1 = {
-	holder = 1228067 # Pål Skoftesson of Giske
+	holder = 1228067 # PÃ¥l Skoftesson of Giske
 }
 1150.1.1 = {
-	holder = 1228068 # Nikolas Pålsson Kuvung of Giske
+	holder = 1228068 # Nikolas PÃ¥lsson Kuvung of Giske
 }
 1217.1.1 = {
-	holder = 1290057 # Pål Nikolasson Flida of Giske
+	holder = 1290057 # PÃ¥l Nikolasson Flida of Giske
 }
 1223.1.1 = {
-	holder = 1290058 # Peter Pålsson of Giske
+	holder = 1290058 # Peter PÃ¥lsson of Giske
 }
 1254.1.1 = {
 	holder = 1290059 # Nikolas Petersson of Giske
@@ -6951,10 +6948,10 @@ c_sunmore = {
 	holder = 1290056 # Bjarne Erlingsson
 }
 1313.7.7 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450790
@@ -6982,20 +6979,20 @@ c_norwegian_more = {
 }
 800.1.1 = {
 	liege = d_trandalog
-	holder = 1228005 # Ivar Halvdansson mørekonge
+	holder = 1228005 # Ivar Halvdansson mÃ¸rekonge
 }
 825.1.1 = {
-	holder = 1228006 # Øystein Ivarsson mørekonge
+	holder = 1228006 # Ã˜ystein Ivarsson mÃ¸rekonge
 }
 858.1.1 = {
-	holder = 1228007 # Hundtjov Mørekonge
+	holder = 1228007 # Hundtjov MÃ¸rekonge
 }
 870.1.1 = {
 	liege = d_viken
-	holder = 161302 # Ragnvaldr Eysteinnsson, Earl of Møre
+	holder = 161302 # Ragnvaldr Eysteinnsson, Earl of MÃ¸re
 }
 892.1.1 = {
-	holder = 186007 # Tore/Thorir Teiande, Earl of Møre
+	holder = 186007 # Tore/Thorir Teiande, Earl of MÃ¸re
 }
 932.1.1 = {
 	liege = k_norway
@@ -7003,10 +7000,10 @@ c_norwegian_more = {
 }
 934.1.1 = {
 	liege = d_trondelag
-	holder = 1290125 # Asbjörn av Austrått
+	holder = 1290125 # AsbjÃ¶rn av AustrÃ¥tt
 }
 970.1.1 = {
-	holder = 1290124 # Jarn-Skjegge Asbjörnsson av Austrått
+	holder = 1290124 # Jarn-Skjegge AsbjÃ¶rnsson av AustrÃ¥tt
 }
 997.1.1 = {
 	liege = k_norway
@@ -7014,7 +7011,7 @@ c_norwegian_more = {
 }
 1000.1.1 = {
 	liege = d_trandalog
-	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, Jämtland and Møre in the settlement following the Battle of Svolder
+	holder = 102514 # Svein Haakonsson of Lade. Was awarded Ranrike, JÃ¤mtland and MÃ¸re in the settlement following the Battle of Svolder
 }
 1015.1.1 = {
 	liege = k_norway
@@ -7030,7 +7027,7 @@ c_norwegian_more = {
 	liege = k_norway
 }
 1051.1.1 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.1.1 = {
 	liege = d_trondelag
@@ -7043,16 +7040,16 @@ c_norwegian_more = {
 	holder = 125 # Scule Kongsfostre, Lord of Rein
 }
 1102.1.2 = {
-	holder = 161124 # Åsulf Sculesson, Lord of Rein
+	holder = 161124 # Ã…sulf Sculesson, Lord of Rein
 }
 1125.1.1 = {
-	holder = 202040 # Guttorm Åsulfsson, Lord of Rein
+	holder = 202040 # Guttorm Ã…sulfsson, Lord of Rein
 }
 1163.1.1 = {
-	holder = 202030 # Bård Guttormsson, Lord of Rein, father of the later King Inge II (1204-1217) Prominent Birkebeiner during the Civil Wars
+	holder = 202030 # BÃ¥rd Guttormsson, Lord of Rein, father of the later King Inge II (1204-1217) Prominent Birkebeiner during the Civil Wars
 }
 1200.1.1 = {
-	holder = 202034 # Earl Skule aka. Skule Bårdsson. Lord of Rein, Earl from 1217 onwards, Duke from 1237 onwards, King from 1239
+	holder = 202034 # Earl Skule aka. Skule BÃ¥rdsson. Lord of Rein, Earl from 1217 onwards, Duke from 1237 onwards, King from 1239
 }
 1240.5.24 = {
 	holder = 202035
@@ -7064,10 +7061,10 @@ c_norwegian_more = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450780
@@ -7106,7 +7103,7 @@ c_firdafylki = {
 	holder = 1290096 # Thord Brynjulfsson, Lendmann of Aurland
 }
 952.1.1 = {
-	holder = 1290097 # Arinbjörn Herse
+	holder = 1290097 # ArinbjÃ¶rn Herse
 }
 970.1.1 = {
 	liege = d_trondelag
@@ -7136,7 +7133,7 @@ c_firdafylki = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7151,13 +7148,13 @@ c_firdafylki = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -7166,28 +7163,28 @@ c_firdafylki = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	liege = d_trondelag
@@ -7268,7 +7265,7 @@ c_hedmork = {
 	liege = k_norway
 }
 998.1.1 = {
-	holder = 1290100 # Rørek Dagsson
+	holder = 1290100 # RÃ¸rek Dagsson
 }
 1000.1.1 = {
 	liege = d_trondelag
@@ -7298,7 +7295,7 @@ c_hedmork = {
 	liege = d_trondelag
 }
 1120.1.1 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7313,13 +7310,13 @@ c_hedmork = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -7335,7 +7332,7 @@ c_hedmork = {
 	holder = 202034
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1240.5.24 = {
 	holder = 202035
@@ -7347,10 +7344,10 @@ c_hedmork = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450670
@@ -7416,7 +7413,7 @@ c_gudbrandsdalir = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7441,28 +7438,28 @@ c_gudbrandsdalir = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
-	holder = 202509 # Håkon Håkonsson
+	holder = 202509 # HÃ¥kon HÃ¥konsson
 }
 1263.12.15 = {
-	holder = 6905 # Magnus Lagaböter
+	holder = 6905 # Magnus LagabÃ¶ter
 }
 1280.5.9 = {
-	holder = 6906 # Erik 'Prästhatare' Magnusson
+	holder = 6906 # Erik 'PrÃ¤sthatare' Magnusson
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	liege = k_norway
@@ -7476,7 +7473,7 @@ c_gudbrandsdalir = {
 c_eystridalir = {
 
 863.1.1 = {
-	holder = 1228047 # Härjulf Hornbreaker
+	holder = 1228047 # HÃ¤rjulf Hornbreaker
 }
 900.1.1 = {
 	#holder = 0
@@ -7513,7 +7510,7 @@ c_eystridalir = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7528,13 +7525,13 @@ c_eystridalir = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -7571,10 +7568,10 @@ c_gauldala = {
 
 830.1.1 = {
 	liege = d_trondelag
-	holder = 186002 # Grjotgard Herlaugsson of Lade, Jarl of lade and Håløy
+	holder = 186002 # Grjotgard Herlaugsson of Lade, Jarl of lade and HÃ¥lÃ¸y
 }
 860.1.1 = {
-	holder = 186003 # Håkon Grjotgardsson of Lade, Jarl of lade and Håløy
+	holder = 186003 # HÃ¥kon Grjotgardsson of Lade, Jarl of lade and HÃ¥lÃ¸y
 }
 917.1.1 = {
 	holder = 1228055 # Sigurd Haakonsson of Lade, Jarl of Lade
@@ -7600,7 +7597,7 @@ c_gauldala = {
 	holder = 102554 # Einar Thambarskelfir
 }
 1047.1.1 = {
-	holder = 102531 # Harald Hardråde
+	holder = 102531 # Harald HardrÃ¥de
 }
 1066.9.26 = {
 	holder = 102532 # Magnus Haraldson
@@ -7609,7 +7606,7 @@ c_gauldala = {
 	holder = 102534 # Olof Haraldson
 }
 1093.1.1 = {
-	holder = 102577 # Håkon Magnuson
+	holder = 102577 # HÃ¥kon Magnuson
 }
 1094.6.6 = {
 	holder = 202511 # Magnus Barfot
@@ -7618,7 +7615,7 @@ c_gauldala = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7633,13 +7630,13 @@ c_gauldala = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -7648,13 +7645,13 @@ c_gauldala = {
 	holder = 202500 # Sverre Sigurdsson
 }
 1202.3.9 = {
-	holder = 202502 # Håkon Sverreson
+	holder = 202502 # HÃ¥kon Sverreson
 }
 1204.1.1 = {
 	holder = 202508 # Guttorm Sigurdsson
 }
 1204.8.11 = {
-	holder = 202032 # Inge Bårdsson
+	holder = 202032 # Inge BÃ¥rdsson
 }
 1217.4.23 = {
 	holder = 202034
@@ -7669,10 +7666,10 @@ c_gauldala = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450790
@@ -7697,7 +7694,7 @@ d_halogaland = {
 		holder = 222598 # Olaf Magnusson
 	}
 	1115.12.22 = {
-		holder = 222597 # Øystein Magnusson
+		holder = 222597 # Ã˜ystein Magnusson
 	}
 	1123.8.29 = {
 		holder = 222595 # Sigurd Magnusson
@@ -7712,13 +7709,13 @@ d_halogaland = {
 		holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 	}
 	1155.6.10 = {
-		holder = 202514 # Øystein, son of Harald Gille
+		holder = 202514 # Ã˜ystein, son of Harald Gille
 	}
 	1157.8.21 = {
 		holder = 202512 # Inge Krokrygg, son of Harald Gille
 	}
 	1161.1.5 = {
-		holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+		holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 	}
 	1162.7.7 = {
 		holder = 202051 # Magnus Erlingsson
@@ -7745,10 +7742,10 @@ d_halogaland = {
 		holder = 6906
 	}
 	1299.7.15 = {
-		holder = 452510 # Håkon Magnusson
+		holder = 452510 # HÃ¥kon Magnusson
 	}
 	1319.5.8 = {
-		holder = 450500 # Magnus Eriksson (Bjälbo)
+		holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 	}
 	1337.1.1 = {
 		holder = 450780
@@ -7770,10 +7767,10 @@ c_vastvag = {
 	holder = 1228056
 }
 972.1.1 = {
-	holder = 1290042 # Tore of Bjarkøy 
+	holder = 1290042 # Tore of BjarkÃ¸y 
 }
 991.1.1 = {
-	holder = 1290039 # Tore Hund of Bjarkøy 
+	holder = 1290039 # Tore Hund of BjarkÃ¸y 
 }
 995.1.1 = {
 	liege = k_norway
@@ -7791,40 +7788,40 @@ c_vastvag = {
 	liege = k_norway
 }
 1031.1.1 = {
-	holder = 1290044 # Sigurd Toresson of Bjarkøy
+	holder = 1290044 # Sigurd Toresson of BjarkÃ¸y
 }
 1040.1.1 = {
-	holder = 1290045 # Ragnhild Sigurdsdatter of Bjarkøy
+	holder = 1290045 # Ragnhild Sigurdsdatter of BjarkÃ¸y
 }
 1058.1.1 = {
-	holder = 1290047 # Jon Arnesson of Giske-Bjarkøy
+	holder = 1290047 # Jon Arnesson of Giske-BjarkÃ¸y
 }
 1066.1.1 = {
 	liege = d_trondelag
 }
 1097.1.1 = {
-	holder = 1290048 # Vidkun Jonsson of Giske-Bjarkøy
+	holder = 1290048 # Vidkun Jonsson of Giske-BjarkÃ¸y
 }
 1138.1.1 = {
-	holder = 1290062 # Erling Vidkunsson of Giske-Bjarkøy
+	holder = 1290062 # Erling Vidkunsson of Giske-BjarkÃ¸y
 }
 1182.1.1 = {
-	holder = 1290063 # Vidkun Erlingsson of Giske-Bjarkøy
+	holder = 1290063 # Vidkun Erlingsson of Giske-BjarkÃ¸y
 }
 1183.1.1 = {
-	holder = 1290065 # Bjarne Mårdsson
+	holder = 1290065 # Bjarne MÃ¥rdsson
 }
 1223.1.1 = {
-	holder = 1290066 # Ivar Bjarnesson of Mårdsson-Bjarkøy
+	holder = 1290066 # Ivar Bjarnesson of MÃ¥rdsson-BjarkÃ¸y
 }
 1230.1.1 = {
-	holder = 1290055 # Erling Ivarsson of Mårdsson-Bjarkøy
+	holder = 1290055 # Erling Ivarsson of MÃ¥rdsson-BjarkÃ¸y
 }
 1275.1.1 = {
-	holder = 1290056 # Bjarne Erlingsson of Mårdsson-Bjarkøy
+	holder = 1290056 # Bjarne Erlingsson of MÃ¥rdsson-BjarkÃ¸y
 }
 1313.7.7 = {
-	holder = 450780 # Erling Vidkunsson of Mårdsson-Bjarkøy, inherited Bjarkøy from his uncle
+	holder = 450780 # Erling Vidkunsson of MÃ¥rdsson-BjarkÃ¸y, inherited BjarkÃ¸y from his uncle
 }
 
 
@@ -7835,16 +7832,16 @@ c_bothin = {
 
 830.1.1 = {
 	liege = d_trondelag
-	holder = 168365 # Björgolf of Torga
+	holder = 168365 # BjÃ¶rgolf of Torga
 }
 866.1.1 = {
 	holder = 168366 # Brynjolf of Torga
 }
 875.1.1 = {
-	holder = 168371 # Bård of Torga
+	holder = 168371 # BÃ¥rd of Torga
 }
 882.1.1 = {
-	holder = 1228034 # Bård Brynjulfson dies after the battle at Hafrsfjord and gives the estates at Torga to Torolv Kveldulvsson
+	holder = 1228034 # BÃ¥rd Brynjulfson dies after the battle at Hafrsfjord and gives the estates at Torga to Torolv Kveldulvsson
 }
 900.1.1 = {
 	#holder = 0 # Torolv Kveldulvson slain
@@ -7853,10 +7850,10 @@ c_bothin = {
 	holder = 1290118 # Finn Eyvindsson
 }
 946.1.1 = {
-	holder = 1290049 # Eystein of Tjøtta/Eystein Skaldaspillir
+	holder = 1290049 # Eystein of TjÃ¸tta/Eystein Skaldaspillir
 }
 992.1.1 = {
-	holder = 1228168 # Hårek of Tjøtta
+	holder = 1228168 # HÃ¥rek of TjÃ¸tta
 }
 995.1.1 = {
 	liege = k_norway
@@ -7874,20 +7871,20 @@ c_bothin = {
 	liege = k_norway
 }
 1036.1.1 = {
-	holder = 1228073 # Åsmund Grankjellson of Dønna
+	holder = 1228073 # Ã…smund Grankjellson of DÃ¸nna
 }
 1052.1.1 = {
-	holder = 1290051 # Einar "Fluga" Håreksson of Tjøtta
+	holder = 1290051 # Einar "Fluga" HÃ¥reksson of TjÃ¸tta
 }
 1066.1.1 = {
 	liege = d_trondelag
-	holder = 1290052 # Finn Håreksson of Tjøtta
+	holder = 1290052 # Finn HÃ¥reksson of TjÃ¸tta
 }
 1074.1.1 = {
-	holder = 1290050 # Håkon Finnson of Tjøtta
+	holder = 1290050 # HÃ¥kon Finnson of TjÃ¸tta
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -7902,13 +7899,13 @@ c_bothin = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -7932,10 +7929,10 @@ c_bothin = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 1337.1.1 = {
 	holder = 450780
@@ -7949,10 +7946,10 @@ c_namdalfylki = {
 
 830.1.1 = {
 	liege = d_trondelag
-	holder = 186002 # Grjotgard Herlaugsson Jarl of lade and Håløy
+	holder = 186002 # Grjotgard Herlaugsson Jarl of lade and HÃ¥lÃ¸y
 }
 860.1.1 = {
-	holder = 186003 # Håkon Grjotgardsson Jarl of lade and Håløy
+	holder = 186003 # HÃ¥kon Grjotgardsson Jarl of lade and HÃ¥lÃ¸y
 }
 917.1.1 = {
 	holder = 1228055 # Sigurd Haakonsson Jarl of Lade
@@ -7961,7 +7958,7 @@ c_namdalfylki = {
 	holder = 1228056 # Haakon Sigurdsson
 }
 992.1.1 = {
-	holder = 1228168 # Hårek of Tjøtta
+	holder = 1228168 # HÃ¥rek of TjÃ¸tta
 }
 995.1.1 = {
 	liege = k_norway
@@ -7979,20 +7976,20 @@ c_namdalfylki = {
 	liege = k_norway
 }
 1036.1.1 = {
-	holder = 1228073 # Åsmund Grankjellson of Dønna
+	holder = 1228073 # Ã…smund Grankjellson of DÃ¸nna
 }
 1052.1.1 = {
-	holder = 1290051 # Einar "Fluga" Håreksson of Tjøtta
+	holder = 1290051 # Einar "Fluga" HÃ¥reksson of TjÃ¸tta
 }
 1066.1.1 = {
 	liege = d_trondelag
-	holder = 1290052 # Finn Håreksson of Tjøtta
+	holder = 1290052 # Finn HÃ¥reksson of TjÃ¸tta
 }
 1074.1.1 = {
-	holder = 1290050 # Håkon Finnson of Tjøtta
+	holder = 1290050 # HÃ¥kon Finnson of TjÃ¸tta
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -8007,13 +8004,13 @@ c_namdalfylki = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -8037,10 +8034,10 @@ c_namdalfylki = {
 	holder = 6906
 }
 1299.7.15 = {
-	holder = 452510 # Håkon Magnusson
+	holder = 452510 # HÃ¥kon Magnusson
 }
 1319.5.8 = {
-	holder = 450500 # Magnus Eriksson (Bjälbo)
+	holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 }
 
 
@@ -8877,7 +8874,7 @@ c_helgum = {
 c_harjadalen = {
 
 863.1.1 = {
-	holder = 1228047 # Härjulf Hornbreaker
+	holder = 1228047 # HÃ¤rjulf Hornbreaker
 }
 900.1.1 = {
 	#holder = 0
@@ -8914,7 +8911,7 @@ c_harjadalen = {
 	holder = 222598 # Olaf Magnusson
 }
 1115.12.22 = {
-	holder = 222597 # Øystein Magnusson
+	holder = 222597 # Ã˜ystein Magnusson
 }
 1123.8.29 = {
 	holder = 222595 # Sigurd Magnusson
@@ -8929,13 +8926,13 @@ c_harjadalen = {
 	holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 }
 1155.6.10 = {
-	holder = 202514 # Øystein, son of Harald Gille
+	holder = 202514 # Ã˜ystein, son of Harald Gille
 }
 1157.8.21 = {
 	holder = 202512 # Inge Krokrygg, son of Harald Gille
 }
 1161.1.5 = {
-	holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+	holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 }
 1162.7.7 = {
 	holder = 202051 # Magnus Erlingsson
@@ -9607,7 +9604,7 @@ d_finland = {
 	liege = 0
 }
 1318.2.16 = {
-	liege = k_sweden # Duke Valdemar dies at Nyköpingshus
+	liege = k_sweden # Duke Valdemar dies at NykÃ¶pingshus
 	holder = 450504 # King Birger
 }
 1320.1.1 = {
@@ -9657,7 +9654,7 @@ c_finland = {
 	holder = 200490 # Erik the Holy
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -9678,19 +9675,19 @@ c_finland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1284.1.1 = {
 	liege = d_finland
@@ -9812,7 +9809,7 @@ c_satakunta = {
 	holder = 200490 # Erik the Holy
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -9833,19 +9830,19 @@ c_satakunta = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1284.1.1 = {
 	liege = d_finland
@@ -9881,16 +9878,16 @@ c_aland = {
 }
 925.1.1 = {
 	liege = 0
-	holder = 1234031 # Gorm of Åland, placeholder
+	holder = 1234031 # Gorm of Ã…land, placeholder
 }
 948.1.1 = {
-	holder = 1234030 # Olve of Åland, placeholder
+	holder = 1234030 # Olve of Ã…land, placeholder
 }
 984.1.1 = {
-	holder = 1234029 # Sigurdr of Åland, placeholder
+	holder = 1234029 # Sigurdr of Ã…land, placeholder
 }
 1006.1.1 = {
-	holder = 1234028 # Kettil of Åland, placeholder
+	holder = 1234028 # Kettil of Ã…land, placeholder
 }
 1022.1.1 = {
 	holder = 1234012
@@ -9919,19 +9916,19 @@ c_aland = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1290.12.18 = {
 	holder = 450504 # Birger Magnusson
@@ -9989,7 +9986,7 @@ c_messukyla = {
 	holder = 200490 # Erik the Holy
 }
 1160.6.6 = {
-	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+	holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 }
 1161.6.6 = {
 	holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -10010,19 +10007,19 @@ c_messukyla = {
 	holder = 200609 # Johan, son of Sverker (200604)
 }
 1222.3.10 = {
-	holder = 200507 # Erik 'den Läspe och Halte'
+	holder = 200507 # Erik 'den LÃ¤spe och Halte'
 }
 1229.11.29 = {
-	holder = 200508 # Knut Holmgersson 'den Långe'
+	holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 }
 1234.6.6 = {
-	holder = 200507 # Erik 'den Läspe och Halte', reinstated
+	holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 }
 1250.2.2 = {
 	holder = 450506 # Valdemar Birgersson
 }
 1275.7.22 = {
-	holder = 450502 # Magnus 'Ladulås'
+	holder = 450502 # Magnus 'LadulÃ¥s'
 }
 1284.1.1 = {
 	liege = d_finland
@@ -10506,7 +10503,7 @@ c_pedersore = {
 		holder = 200490 # Erik the Holy
 	}
 	1160.6.6 = {
-		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 	}
 	1161.6.6 = {
 		holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -10527,19 +10524,19 @@ c_pedersore = {
 		holder = 200609 # Johan, son of Sverker (200604)
 	}
 	1222.3.10 = {
-		holder = 200507 # Erik 'den Läspe och Halte'
+		holder = 200507 # Erik 'den LÃ¤spe och Halte'
 	}
 	1229.11.29 = {
-		holder = 200508 # Knut Holmgersson 'den Långe'
+		holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 	}
 	1234.6.6 = {
-		holder = 200507 # Erik 'den Läspe och Halte', reinstated
+		holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 	}
 	1250.2.2 = {
 		holder = 450506 # Valdemar Birgersson
 	}
 	1275.7.22 = {
-		holder = 450502 # Magnus 'Ladulås'
+		holder = 450502 # Magnus 'LadulÃ¥s'
 	}
 	1284.1.1 = {
 		liege = "d_finland"
@@ -10602,7 +10599,7 @@ c_mustasaari = {
 		holder = 200490 # Erik the Holy
 	}
 	1160.6.6 = {
-		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'Skadelår'
+		holder = 100553 # Magnus Henriksson, son of Danish prince Henrik 'SkadelÃ¥r'
 	}
 	1161.6.6 = {
 		holder = 200602 # Karl Sverkersson, son of Sverker the Older
@@ -10623,19 +10620,19 @@ c_mustasaari = {
 		holder = 200609 # Johan, son of Sverker (200604)
 	}
 	1222.3.10 = {
-		holder = 200507 # Erik 'den Läspe och Halte'
+		holder = 200507 # Erik 'den LÃ¤spe och Halte'
 	}
 	1229.11.29 = {
-		holder = 200508 # Knut Holmgersson 'den Långe'
+		holder = 200508 # Knut Holmgersson 'den LÃ¥nge'
 	}
 	1234.6.6 = {
-		holder = 200507 # Erik 'den Läspe och Halte', reinstated
+		holder = 200507 # Erik 'den LÃ¤spe och Halte', reinstated
 	}
 	1250.2.2 = {
 		holder = 450506 # Valdemar Birgersson
 	}
 	1275.7.22 = {
-		holder = 450502 # Magnus 'Ladulås'
+		holder = 450502 # Magnus 'LadulÃ¥s'
 	}
 	1284.1.1 = {
 		liege = "d_finland"
@@ -11615,7 +11612,7 @@ c_rounala = {
 		holder = 222598 # Olaf Magnusson
 	}
 	1115.12.22 = {
-		holder = 222597 # Øystein Magnusson
+		holder = 222597 # Ã˜ystein Magnusson
 	}
 	1123.8.29 = {
 		holder = 222595 # Sigurd Magnusson
@@ -11630,13 +11627,13 @@ c_rounala = {
 		holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 	}
 	1155.6.10 = {
-		holder = 202514 # Øystein, son of Harald Gille
+		holder = 202514 # Ã˜ystein, son of Harald Gille
 	}
 	1157.8.21 = {
 		holder = 202512 # Inge Krokrygg, son of Harald Gille
 	}
 	1161.1.5 = {
-		holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+		holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 	}
 	1162.7.7 = {
 		holder = 202051 # Magnus Erlingsson
@@ -11663,10 +11660,10 @@ c_rounala = {
 		holder = 6906
 	}
 	1299.7.15 = {
-		holder = 452510 # Håkon Magnusson
+		holder = 452510 # HÃ¥kon Magnusson
 	}
 	1319.5.8 = {
-		holder = 450500 # Magnus Eriksson (Bjälbo)
+		holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 	}
 	1337.1.1 = {
 		holder = 450780
@@ -11701,7 +11698,7 @@ c_karasjohka = {
 		holder = 222598 # Olaf Magnusson
 	}
 	1115.12.22 = {
-		holder = 222597 # Øystein Magnusson
+		holder = 222597 # Ã˜ystein Magnusson
 	}
 	1123.8.29 = {
 		holder = 222595 # Sigurd Magnusson
@@ -11716,13 +11713,13 @@ c_karasjohka = {
 		holder = 202501 # Sigurd Munn, son of Harald Gille, actually co-regent with 202514 and 202512
 	}
 	1155.6.10 = {
-		holder = 202514 # Øystein, son of Harald Gille
+		holder = 202514 # Ã˜ystein, son of Harald Gille
 	}
 	1157.8.21 = {
 		holder = 202512 # Inge Krokrygg, son of Harald Gille
 	}
 	1161.1.5 = {
-		holder = 202507 # Håkon Herdebrei, son of Sigurd Munn
+		holder = 202507 # HÃ¥kon Herdebrei, son of Sigurd Munn
 	}
 	1162.7.7 = {
 		holder = 202051 # Magnus Erlingsson
@@ -11749,10 +11746,10 @@ c_karasjohka = {
 		holder = 6906
 	}
 	1299.7.15 = {
-		holder = 452510 # Håkon Magnusson
+		holder = 452510 # HÃ¥kon Magnusson
 	}
 	1319.5.8 = {
-		holder = 450500 # Magnus Eriksson (Bjälbo)
+		holder = 450500 # Magnus Eriksson (BjÃ¤lbo)
 	}
 	1337.1.1 = {
 		holder = 450780


### PR DESCRIPTION
Switched around the starting de-jure allegiances of "d_vastergotland" and "d_gotland" for historical accuracy's sake.