### PR TITLE
Update NB_newtitles_l_english.yml

### DIFF
--- a/localization/replace/NB_newtitles_l_english.yml
+++ b/localization/replace/NB_newtitles_l_english.yml
@@ -1520,7 +1520,7 @@
  c_bosco:0 "Bosco"
  b_bosco:0 "Bosco"
  c_monferrato:0 "Asti"
-    
+ b_papenburg:0 "Saterland"
 
 
  


### PR DESCRIPTION
Real life Papenburg is actually located close enough to Leer it would be inside the latter's in-game barony.