### PR TITLE
Allow Kingdom of Aragon to be formed between 867 and 1035

### DIFF
--- a/common/decisions/MB_REPLACE_major_decisions_middle_europe.txt
+++ b/common/decisions/MB_REPLACE_major_decisions_middle_europe.txt
@@ -1,0 +1,92 @@
+#MODIFIED VANILLA EVENTS
+
+##############################
+# Form the Kingdom of Aragon #
+# by Sean Hughes			 #
+##############################
+
+form_the_kingdom_of_aragon_decision = {
+	picture = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds"
+	major = yes
+
+	ai_check_interval = 120
+
+	desc = form_the_kingdom_of_aragon_decision_desc
+	selection_tooltip = form_the_kingdom_of_aragon_decision_tooltip
+
+	is_shown = {
+		#Can't form Aragon if Aragon already formed.
+		# Check against the year the Crown of Aragon was founded to allow it to be formed between 867 and 1066
+                game_start_date <= 1035.1.1
+		highest_held_title_tier <= tier_duchy
+		any_sub_realm_county = {
+			OR = {
+				target_is_de_jure_liege_or_above = title:d_aragon
+				target_is_de_jure_liege_or_above = title:d_barcelona
+			}
+		}
+		NOT = {	
+			is_target_in_global_variable_list = {
+				name = unavailable_unique_decisions
+				target = flag:flag_formed_kingdom_of_aragon
+			}
+		}
+                        
+	}
+
+	is_valid = {
+		is_independent_ruler = yes
+		completely_controls = title:d_aragon
+		completely_controls = title:d_barcelona
+	}
+
+	is_valid_showing_failures_only = {
+		
+	}
+
+	effect = {
+		# De jure shifts.
+		title:d_aragon = { set_de_jure_liege_title = title:k_aragon }
+		title:d_barcelona = { set_de_jure_liege_title = title:k_aragon }
+		hidden_effect = {
+			title:k_aragon = { set_de_jure_liege_title = title:e_spain }
+		}
+
+		# Create kingdom title.
+		create_title_and_vassal_change = {
+			type = created
+			save_scope_as = change
+			add_claim_on_loss = no
+		}
+		title:k_aragon = {
+			change_title_holder = {
+				holder = root
+				change = scope:change
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+		add_prestige = major_prestige_gain
+
+		#Once per game
+		add_to_global_variable_list = {
+			name = unavailable_unique_decisions
+			target = flag:flag_formed_kingdom_of_aragon
+		}
+		set_global_variable = {
+			name = flag_formed_kingdom_of_aragon
+			value = root
+		}
+	}
+
+	cost = {
+		gold = 200
+	}
+
+	ai_potential = {
+		always = yes
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}


### PR DESCRIPTION
In vanilla, the "Form the Kingdom of Aragon" decision is written assuming 867 and 1066 are the only start dates. 

Thus, the decision is only shown to the player if the game's start date is <= 867.1.1. This means that playing in any other time period prior to the year that the Crown of Aragon was actually founded means that it can't actually ever be founded. This change simply changes the date to check against- 1035, the year that it was formed historically.