### PR TITLE
Update MB_central_germanic.txt

### DIFF
--- a/common/culture/cultures/MB_central_germanic.txt
+++ b/common/culture/cultures/MB_central_germanic.txt
@@ -30,22 +30,24 @@ thuringian = { #Based on Franconian
 	}
 }
 
-low_frankish = { #Based on Frisian
+low_frankish = { #Based on Franconian
 	color = { 1.0 0.25 0.0 } 
+	created = 640.1.1 # Frankish settlements appeared along the Rhine during the 7th century
+	parents = { frankish }
 	
-	ethos = ethos_stoic
+	ethos = ethos_courtly
 	heritage = heritage_central_germanic
-	language = language_anglic
+	language = language_dutch
 	martial_custom = martial_custom_male_only
 	traditions = {
-		tradition_fishermen
-		tradition_zealous_people
-		tradition_battlefield_looters
+		tradition_hereditary_hierarchy
+		tradition_astute_diplomats
+		tradition_castle_keepers
 	}
 	
-	name_list = name_list_frisian
+	name_list = name_list_franconian
 
-	coa_gfx = { frisian_coa_gfx german_group_coa_gfx western_coa_gfx } 
+	coa_gfx = { german_group_coa_gfx western_coa_gfx } 
 	building_gfx = { western_building_gfx } 
 	clothing_gfx = { dde_hre_clothing_gfx western_clothing_gfx } 
 	unit_gfx = { western_unit_gfx } 		


### PR DESCRIPTION
Culturally, the Old Dutch were just Franconians who spoke a different dialect than their cousins upstream.