### PR TITLE
Corrected Mont Saint Michel's location

### DIFF
--- a/history/provinces/k_france.txt
+++ b/history/provinces/k_france.txt
@@ -402,6 +402,10 @@
 ###c_avranches
 2167 = {	#AVRANCHES
 	culture = frankish
+	#Mont Saint Michel
+	769.1.1 = {
+		special_building_slot = sba_mont_saint_michel_01
+	}
 	790.1.1 = { culture = french }
 
 	religion = catholic
@@ -477,10 +481,6 @@
 ###c_lisieux
 2174 = {	#LISIEUX
 	culture = frankish
-	#Mont Saint Michel
-	769.1.1 = {
-		special_building_slot = sba_mont_saint_michel_01
-	}
 	790.1.1 = { culture = french }
 
 	religion = catholic


### PR DESCRIPTION
Corrected the special building location for Mont Saint Michel

https://en.wikipedia.org/wiki/Mont-Saint-Michel 